### PR TITLE
Group failing spec by error message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in failing_spec_detector.gemspec
 gemspec
+
+gem 'pry'
+gem 'rspec', '~>3.12'
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,68 @@
+PATH
+  remote: .
+  specs:
+    failing_spec_detector (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    method_source (1.0.0)
+    parallel (1.23.0)
+    parser (3.2.2.4)
+      ast (~> 2.4.1)
+      racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.7.3)
+    rainbow (3.1.1)
+    rake (10.5.0)
+    regexp_parser (2.8.2)
+    rexml (3.2.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    rubocop (1.57.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  bundler
+  failing_spec_detector!
+  pry
+  rake (~> 10.0)
+  rspec (~> 3.12)
+  rubocop
+
+BUNDLED WITH
+   2.2.11

--- a/README.md
+++ b/README.md
@@ -1,15 +1,39 @@
 # FailingSpecDetector
+  A rspec extension introdusing a custom formatter, to detect failing specs and group them by exception.
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/failing_spec_detector`. To experiment with that code, run `bin/console` for an interactive prompt.
+### Output Example
+> log.txt:
 
-TODO: Delete this and the text above, and describe your gem
+```txt
+Failing spec detector:
+Test Exception 1:
 
+/spec/one_spec.rb:11:in `some_method':
+/spec/two_spec.rb:20:in `some_method':
+
+
+
+Test Exception 2:
+
+/spec/one_spec.rb:14:in `some_method':
+/spec/three_spec.rb:4:in `some_method':
+
+
+
+Test Exception 3:
+
+/spec/three_spec.rb:4:in `some_method':
+
+
+
+----------------------------------------------------------------
+```
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'failing_spec_detector'
+gem 'failing_spec_detector', github: 'nebulab/failing_spec_detector'
 ```
 
 And then execute:
@@ -22,7 +46,20 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+Add this lines to your application's .rspec file:
+
+```ruby
+  --require failing_spec_detector/failing_spec_formatter.rb
+  --format FailingSpecDetector::FailingSpecFormatter
+```
+
+And run your test suite:
+
+    $ rspec spec
+
+Or run your test suite using this command:
+
+    $ rspec spec --require failing_spec_detector/failing_spec_formatter.rb --format FailingSpecDetector::FailingSpecFormatter
 
 ## Development
 
@@ -32,7 +69,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/failing_spec_detector.
+Bug reports and pull requests are welcome on GitHub at https://github.com/nebulab/failing_spec_detector/issues.
 
 ## License
 

--- a/failing_spec_detector.gemspec
+++ b/failing_spec_detector.gemspec
@@ -9,19 +9,21 @@ Gem::Specification.new do |spec|
   spec.authors       = ["safa"]
   spec.email         = ["aballaghsafa@gmail.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = 'A tool to detect failing specs and group them by error message'
+  spec.description   = <<~DESCRIPTION
+    Automatic Failing spec detector.
+    Introduces a custom rspec formatter to detect failing specs and group them by exception.
+  DESCRIPTION
+  spec.homepage      = "https://github.com/nebulab/failing_spec_detector"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
     spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-    spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+    spec.metadata["source_code_uri"] = "https://github.com/nebulab/failing_spec_detector"
+    # spec.metadata["changelog_uri"] = "https://github.com/nebulab/failing_spec_detector"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."
@@ -36,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/failing_spec_detector/failing_spec_formatter.rb
+++ b/lib/failing_spec_detector/failing_spec_formatter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rspec/core/formatters/base_text_formatter'
+
+module FailingSpecDetector
+  class FailingSpecFormatter < RSpec::Core::Formatters::BaseTextFormatter
+    RSpec::Core::Formatters.register self, :example_failed, :stop
+
+    def initialize(output)
+      super(output)
+      @failures = []
+      @exceptions = []
+      @filename = 'log.txt'
+    end
+
+    def example_failed(failure)
+      exception = failure.exception.to_s.gsub(/\e\[(\d+)m/, '')
+
+      @exceptions << exception unless @exceptions.include?(exception)
+
+      @failures << failure
+    end
+
+    def stop(_notification)
+      File.open(@filename, 'w') { |f| f.write "Failing spec detector:\n" }
+      return if @exceptions.empty?
+
+      @exceptions.each do |exception|
+        File.write(@filename, "#{exception}:\n\n", mode: 'a')
+        related_examples = @failures.select { |failure| failure.exception.to_s.gsub(/\e\[(\d+)m/, '') == exception }
+        next if related_examples.empty?
+
+        related_examples.each do |failure|
+          File.write(@filename, "#{failure.formatted_backtrace.join("\n")}:\n", mode: 'a')
+        end
+        File.write(@filename, "\n\n\n", mode: 'a')
+      end
+      File.write(@filename, '----------------------------------------------------------------', mode: 'a')
+    end
+  end
+end

--- a/spec/failing_spec_detector/failing_spec_formatter_spec.rb
+++ b/spec/failing_spec_detector/failing_spec_formatter_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FailingSpecDetector::FailingSpecFormatter do
+  let(:formatter) { described_class.new(output) }
+  let(:output) { Tempfile.new('./output_to_close') }
+  let(:expected_file_path) { './spec/support/expected_file.txt' }
+  let(:actual_file_path) { './log.txt' }
+  let(:expected_file) { File.new(expected_file_path, 'r') }
+  let(:actual_file) { File.new(actual_file_path, 'r') }
+
+  let(:examples) { [failed_notification1, failed_notification2, failed_notification3] }
+  let(:expected_exceptions) { [failed_notification1.exception.to_s, failed_notification3.exception.to_s] }
+  let(:failed_notification1)  { ::RSpec::Core::Notifications::ExampleNotification.for(failed_example1) }
+  let(:failed_notification2)  { ::RSpec::Core::Notifications::ExampleNotification.for(failed_example2) }
+  let(:failed_notification3)  { ::RSpec::Core::Notifications::ExampleNotification.for(failed_example3) }
+  let(:failed_example1) do
+    exception = ::RuntimeError.new('Test Error 1')
+    exception.set_backtrace ["/spec/one_spec.rb:11:in `some_method'"]
+
+    example = self.class.example
+
+    example.metadata[:file_path] = '/spec/one_spec.rb'
+    example.metadata[:execution_result].status = :failed
+    example.metadata[:execution_result].exception = exception
+
+    example
+  end
+
+  let(:failed_example2) do
+    exception = ::RuntimeError.new('Test Error 1')
+    exception.set_backtrace ["/spec/two_spec.rb:20:in `some_method'"]
+
+    example = self.class.example
+
+    example.metadata[:file_path] = '/spec/two_spec.rb'
+    example.metadata[:execution_result].status = :failed
+    example.metadata[:execution_result].exception = exception
+
+    example
+  end
+
+  let(:failed_example3) do
+    exception = ::RuntimeError.new('Test Error 2')
+    exception.set_backtrace ["/spec/three_spec.rb:4:in `some_method'"]
+
+    example = self.class.example
+
+    example.metadata[:file_path] = '/spec/three_spec.rb'
+    example.metadata[:execution_result].status = :failed
+    example.metadata[:execution_result].exception = exception
+
+    example
+  end
+
+  it 'prints the failing specs backtraces grouped by exception' do
+    mock_run_specs
+    expect(FileUtils.compare_file(actual_file, expected_file)).to be_truthy
+  end
+
+  def mock_run_specs
+    examples.each do |example|
+      formatter.example_failed(example)
+    end
+
+    formatter.stop(:stop)
+  end
+end

--- a/spec/failing_spec_detector_spec.rb
+++ b/spec/failing_spec_detector_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe FailingSpecDetector do
   it "has a version number" do
     expect(FailingSpecDetector::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require "bundler/setup"
-require "failing_spec_detector"
+require "failing_spec_detector/failing_spec_formatter"
+require 'fileutils'
+require 'tempfile'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/expected_file.txt
+++ b/spec/support/expected_file.txt
@@ -1,0 +1,15 @@
+Failing spec detector:
+Test Error 1:
+
+/spec/one_spec.rb:11:in `some_method':
+/spec/two_spec.rb:20:in `some_method':
+
+
+
+Test Error 2:
+
+/spec/three_spec.rb:4:in `some_method':
+
+
+
+----------------------------------------------------------------


### PR DESCRIPTION
## Description:

This PR adds a custom rspec formatter, allows us to detect failing specs and group them by exception. the formatter prints the results in a text file.

## How to test: 

To test this on a rails project:
Add the gem to the Gemfile then run the rspec command using these flags: 
`bundle exec rspec --require failing_spec_detector/failing_spec_formatter.rb  --format FailingSpecDetector::FailingSpecFormatter`

##Example:
<img width="1196" alt="Screenshot 2023-12-04 at 10 46 49" src="https://github.com/nebulab/failing_spec_detector/assets/43698511/c0a0ea18-7e9e-4129-a3a0-20bc8c6959e3">
